### PR TITLE
Adjust backup schedule to every 3 hours

### DIFF
--- a/.github/workflows/backup.yaml
+++ b/.github/workflows/backup.yaml
@@ -7,7 +7,7 @@ on:
     branches: [main, dev]
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * *" # Runs every day at midnight
+    - cron: "0 */3 * * *" # Runs every 3 hours
 
 env:
   BACKUP_ENABLED: true


### PR DESCRIPTION
## Summary
- update GitHub Actions cron schedule so backups run every 3 hours

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68404ee8d91883309833631ab7788f44